### PR TITLE
Adds the Help Command to the DNS

### DIFF
--- a/jokes.js
+++ b/jokes.js
@@ -22,5 +22,6 @@ exports.setups = [
     'Not endorsed by ISC, definitely not a part of the BIND package either!',
     'Made by Phpminor, who should REALLY consider changing his username!',
     'JS-Dig\'s birthday is August 8th, 2021.\nPlease consider wishing it \033[32mhappy birthday\033[0m when that comes around',
-    'Too horizontal for you?\nTry the \033[32m+newlines\033[0m argument at the end.'
+    'Too horizontal for you?\nTry the \033[32m+newlines\033[0m argument at the end.',
+    'You can get the help menu by replacing the port with "+help"'
   ]

--- a/jsdig.js
+++ b/jsdig.js
@@ -74,7 +74,7 @@ if(args[3].toLowerCase() === '+help') {
   process.stdout.write('\n If you write \033[32mbirthday\033[0m instead of the port\n you can congratulate DiG with his birthday!')
   process.stdout.write('\n You can get a \033[32mgood old pun\033[0m if your DNS has failed!\n')
   process.stdout.write('\n \033[32mHave fun!\033[0m')
-  process.exit(1)
+  process.exit(0)
 }
 
 

--- a/jsdig.js
+++ b/jsdig.js
@@ -68,6 +68,16 @@ if(process.argv.length <= 7 && process.argv[6] === '+newlines') {
   bindStyle = true
 };
 
+if(args[3].toLowerCase() === '+help') {
+  process.stdout.write('\n \n \n \n \n \n Welcome to the \033[32mhelp menu\033[0m! Here you can find some information about me!:\n ')
+  process.stdout.write('\n If you write \033[32m+newlines\033[0m at the end of your command, you can get better lines!')
+  process.stdout.write('\n If you write \033[32mbirthday\033[0m instead of the port\n you can congratulate DiG with his birthday!')
+  process.stdout.write('\n You can get a \033[32mgood old pun\033[0m if your DNS has failed!\n')
+  process.stdout.write('\n \033[32mHave fun!\033[0m')
+  process.exit(1)
+}
+
+
 const options = {
   // available options
   dns: nameservers[0],


### PR DESCRIPTION
### This adds the help command to the DNS, has pretty basic information

This might be needed after other functions would be added.

Replace the port with **"+help"** to access the help menu
**Example to use: node jsdig.js 8.8.8.8 +help www.google.com A**